### PR TITLE
wasabi 0.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "wasabi" %}
-{% set version = "0.8.2" %}
-{% set sha256sum = "b4a36aaa9ca3a151f0c558f269d442afbb3526f0160fd541acd8a0d5e5712054" %}
+{% set version = "0.9.0" %}
+{% set sha256sum = "152245d892030a3a7b511038e9472acff6d0e237cfe4123fef0d147f2d3274fc" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "wasabi" %}
-{% set version = "0.9.0" %}
-{% set sha256sum = "152245d892030a3a7b511038e9472acff6d0e237cfe4123fef0d147f2d3274fc" %}
+{% set version = "0.9.1" %}
+{% set sha256sum = "ada6f13e9b70ef26bf95fad0febdfdebe2005e29a08ad58f4bbae383a97298cf" %}
 
 package:
   name: {{ name|lower }}
@@ -9,8 +9,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256sum }}
+
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -18,15 +18,19 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
   requires:
-    - pytest <4
+    - pip 
+    - pytest
   imports:
     - {{ name }}
   commands:
+    - pip check
     - python -m pytest --tb=native --pyargs {{ name }}
 
 
@@ -38,7 +42,7 @@ about:
   summary: A lightweight console printing and formatting toolkit
 
   dev_url: https://github.com/ines/wasabi
-  doc_url: https://github.com/ines/wasabi#-api
+  doc_url: https://github.com/ines/wasabi/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update wasabi to 0.9.1

License: https://github.com/ines/wasabi/blob/v0.9.1/LICENSE
Requirements: https://github.com/ines/wasabi/blob/v0.9.1/setup.py and https://github.com/ines/wasabi/blob/v0.9.1/requirements.txt

Actions:
1. Remove noarch: python
2. Add setuptools and wheel
3. Add pip check
4. Fix pytest
5. Fix doc url